### PR TITLE
add continent gamemode

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ const gamemodes: Gamemode[] = [
     nLighthouses: 2,
     nIslands: 10,
     clusterSpread: 4,
+    keepFromBorder: false,
     id: 0,
   },
   {
@@ -34,6 +35,7 @@ const gamemodes: Gamemode[] = [
     nLighthouses: 0,
     nIslands: 0,
     clusterSpread: 2,
+    keepFromBorder: false,
     id: 1,
   },
   {
@@ -46,6 +48,7 @@ const gamemodes: Gamemode[] = [
     nLighthouses: 3,
     nIslands: 20,
     clusterSpread: 2,
+    keepFromBorder: false,
     id: 2,
   },
   {
@@ -58,6 +61,7 @@ const gamemodes: Gamemode[] = [
     nLighthouses: 1,
     nIslands: 6,
     clusterSpread: 2,
+    keepFromBorder: false,
     id: 3,
   },
   {
@@ -70,7 +74,21 @@ const gamemodes: Gamemode[] = [
     nLighthouses: 0,
     nIslands: 0,
     clusterSpread: 4,
+    keepFromBorder: false,
     id: 4,
+  },
+  {
+    name: "continent2032",
+    label: "Continent",
+    link: "/continent",
+    w: 20,
+    h: 20,
+    numBombs: 32,
+    nLighthouses: 0,
+    nIslands: 3,
+    clusterSpread: 10,
+    keepFromBorder: true,
+    id: 5,
   },
 ];
 

--- a/frontend/src/components/Game/Game.tsx
+++ b/frontend/src/components/Game/Game.tsx
@@ -22,6 +22,7 @@ const generateBoard = async ({
   numBombs,
   nIslands,
   clusterSpread,
+  keepFromBorder,
 }: Gamemode) => {
   // generates a new board
   let tempBoard;
@@ -33,7 +34,8 @@ const generateBoard = async ({
       h,
       nIslands,
       clusterSpread,
-      0.6
+      0.6,
+      keepFromBorder
     );
     // populate map with bombs
     tempBoard = await gameUtils.populateGeneratedMap(numBombs, tempMap);

--- a/frontend/src/components/Game/GameBoard.tsx
+++ b/frontend/src/components/Game/GameBoard.tsx
@@ -33,6 +33,7 @@ const GameBoard = ({
     clusterSpread,
     numBombs,
     showGamemodeCarousel,
+    keepFromBorder,
   },
   handleToggleGamemodeCarousel,
   handleRefetchHighscores,
@@ -82,7 +83,8 @@ const GameBoard = ({
       h,
       nIslands,
       clusterSpread,
-      0.6
+      0.6,
+      keepFromBorder
     );
     const tempBoard = await gameUtils.populateGeneratedMap(numBombs, tempMap);
     const countWaterTiles = tempBoard.filter((t) => t.type !== 1).length;

--- a/frontend/src/components/Game/islandMapGenerator.ts
+++ b/frontend/src/components/Game/islandMapGenerator.ts
@@ -81,10 +81,15 @@ const generateIsland = (
   mapWidth: number,
   mapHeight: number,
   amountClusterPoints: number,
-  clusterSpread: number
+  clusterSpread: number,
+  keepFromBorder: boolean
 ): MapArray => {
   // generates an island with a given amount of cluster points and clusterSpread
   const map = generateBlankMap(mapWidth, mapHeight);
+  let borderInset = 0;
+
+  // keep from border
+  if (keepFromBorder) borderInset = 4;
 
   // generates a random center point for the island
   const centerPoint: Point = {
@@ -101,10 +106,10 @@ const generateIsland = (
     let newClusterPoint = getClusterPoint(centerPoint, clusterSpread);
 
     while (
-      newClusterPoint.x < 0 ||
-      newClusterPoint.x >= mapWidth ||
-      newClusterPoint.y < 0 ||
-      newClusterPoint.y >= mapHeight ||
+      newClusterPoint.x < 0 + borderInset ||
+      newClusterPoint.x >= mapWidth - borderInset ||
+      newClusterPoint.y < 0 + borderInset ||
+      newClusterPoint.y >= mapHeight - borderInset ||
       newClusterPoint.x === undefined ||
       newClusterPoint.y === undefined
     ) {
@@ -178,7 +183,8 @@ const generateIslandMap = (
   mapWidth: number,
   mapHeight: number,
   nIslands: number,
-  clusterSpread: number
+  clusterSpread: number,
+  keepFromBorder: boolean
 ): MapArray => {
   let islands = [];
 
@@ -192,7 +198,8 @@ const generateIslandMap = (
       mapWidth,
       mapHeight,
       randomNumberCluster,
-      clusterSpread
+      clusterSpread,
+      keepFromBorder
     );
 
     // add island to array
@@ -282,7 +289,8 @@ const generateValidMap = (
   mapHeight: number,
   amountIslands: number,
   clusterSpread: number,
-  waterRatio: number = 0.6
+  waterRatio: number = 0.6,
+  keepFromBorder: boolean
 ): MapArray => {
   // generates maps until a valid map is found
   while (true) {
@@ -290,7 +298,8 @@ const generateValidMap = (
       mapWidth,
       mapHeight,
       amountIslands,
-      clusterSpread
+      clusterSpread,
+      keepFromBorder
     );
 
     const { map, count } = floodFillMap(islandMap);
@@ -321,7 +330,8 @@ const generateValidMergedMap = (
   heigth: number,
   nIslands: number,
   clusterSpread: number,
-  waterRatio: number
+  waterRatio: number,
+  keepFromBorder: boolean
 ) => {
   // generate map
   const validMap = generateValidMap(
@@ -329,7 +339,8 @@ const generateValidMergedMap = (
     heigth,
     nIslands,
     clusterSpread,
-    waterRatio
+    waterRatio,
+    keepFromBorder
   );
   // merge layers
   const mergedMap = mergeLayers(validMap);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -19,6 +19,7 @@ export type Gamemode = {
   clusterSpread: number;
   id: number;
   board?: any;
+  keepFromBorder: boolean;
 };
 
 export type TileType = {


### PR DESCRIPTION
Add contintent gamemode, which generates an island (or a few) in the center of the game board. Also adds new parameter to island map generation, `keepFromBorder` which limits the area where island center points can be randomly set. 